### PR TITLE
replace six dependency by future

### DIFF
--- a/libvmi/libvmi.py
+++ b/libvmi/libvmi.py
@@ -1,6 +1,4 @@
-import six
-from builtins import bytes
-from builtins import object
+from builtins import bytes, object, str
 from enum import Enum
 
 from _libvmi import ffi, lib
@@ -95,7 +93,7 @@ class AccessContext(object):
 
         self.tr_mechanism = tr_mechanism
         if self.tr_mechanism == TranslateMechanism.KERNEL_SYMBOL:
-            if not isinstance(ksym, six.string_types):
+            if not isinstance(ksym, str):
                 raise RuntimeError("ksym must be a string")
             self.ksym = ksym
         self.addr = addr

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='3.0',
     description='Python interface to LibVMI',
     setup_requires=["cffi>=1.6.0", "pkgconfig"],
-    install_requires=["cffi>=1.6.0", "six"],
+    install_requires=["cffi>=1.6.0", "future"],
     cffi_modules=['libvmi/glib_build.py:ffi', 'libvmi/libvmi_build.py:ffi'],
     packages=['libvmi'],
     package_data={


### PR DESCRIPTION
> python-future is a higher-level compatibility layer than six that includes more backported functionality from Python 3, more forward-ported functionality from Python 2, and supports cleaner code, but requires more modern Python versions to run.

> python-future and six share the same goal of making it possible to write a single-source codebase that works on both Python 2 and Python 3. python-future has the further goal of allowing standard Py3 code to run with almost no modification on both Py3 and Py2. future provides a more complete set of support for Python 3’s features, including backports of Python 3 builtins such as the bytes object (which is very different to Python 2’s str object) and several standard library modules.

`future` is the way to go.