### PR TITLE
add vmi_get_va_pages

### DIFF
--- a/libvmi/glib_cdef.h
+++ b/libvmi/glib_cdef.h
@@ -1,10 +1,3 @@
-#!/usr/bin/env python3
-
-
-from cffi import FFI
-import pkgconfig
-
-cdef = """
 typedef int    gint;
 typedef gint   gboolean;
 typedef void* gpointer;
@@ -14,6 +7,13 @@ typedef struct _GHashTable  GHashTable;
 
 typedef guint (*GHashFunc)(gconstpointer key);
 typedef gboolean (*GEqualFunc)(gconstpointer a, gconstpointer b);
+
+typedef struct _GSList GSList;
+
+struct _GSList {
+  gpointer data;
+  GSList *next;
+};
 
 GHashTable* g_hash_table_new               (GHashFunc       hash_func,
                                             GEqualFunc      key_equal_func);
@@ -26,23 +26,7 @@ void        g_hash_table_destroy           (GHashTable     *hash_table);
 
 guint    g_str_hash     (gconstpointer  v);
 gboolean g_str_equal    (gconstpointer  v1, gconstpointer  v1);
-"""
 
+void g_free (gpointer mem);
 
-ffi = FFI()
-includes = pkgconfig.cflags('glib-2.0')
-if not includes:
-    raise RuntimeError('Unable to find pkgconfig for glib-2.0')
-includes = includes.replace('-I', '').split(' ')
-
-# set source
-ffi.set_source("_glib",
-               """
-               #include <glib.h>
-               """,
-               libraries=['glib-2.0'], include_dirs=includes)
-
-ffi.cdef(cdef)
-
-if __name__ == "__main__":
-    ffi.compile(verbose=True)
+void g_slist_free (GSList *list);

--- a/libvmi/libvmi_build.py
+++ b/libvmi/libvmi_build.py
@@ -2,24 +2,69 @@
 
 
 import os
+
+import pkgconfig
 from cffi import FFI
 
-CDEF_FILE = 'libvmi_cdef.h'
+# glib_cdef.h must be first
+CDEF_HEADERS = [
+    'glib_cdef.h',
+    'libvmi_cdef.h',
+    'libvmi_extra_cdef.h'
+]
 
+
+def get_cflags(package):
+    includes = pkgconfig.cflags(package)
+    if not includes:
+        raise RuntimeError('Unable to find pkgconfig cflags'
+                           ' for {}'.format(package))
+    includes = includes.replace('-I', '').split(' ')
+    return includes
+
+
+def get_libs(package):
+    libs = pkgconfig.libs(package)
+    if not libs:
+        raise RuntimeError('Unable to find pkgconfig libs'
+                           ' for {}'.format(package))
+    libs = libs.replace('-l', '').split(' ')
+    return libs
+
+
+# glib cflags and libs
+glib_includes = get_cflags('glib-2.0')
+glib_libs = get_libs('glib-2.0')
+
+# get libvmi libs
+libvmi_libs = get_libs('libvmi')
+
+includes = []
+includes.extend(glib_includes)
+
+libs = []
+libs.extend(libvmi_libs)
+libs.extend(glib_libs)
 
 ffi = FFI()
 # set source
 ffi.set_source("_libvmi",
                """
                #include <libvmi/libvmi.h>
+               #include <libvmi/libvmi_extra.h>
                """,
-               libraries=['vmi'])
+               libraries=libs, include_dirs=includes)
+
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 # we read our C definitions from an external file
 # easier to maintain + C syntax highlighting
-with open(os.path.join(script_dir, CDEF_FILE)) as cdef_file:
-    cdef_content = cdef_file.read()
+cdef_content = ""
+for cdef_path in CDEF_HEADERS:
+    with open(os.path.join(script_dir, cdef_path)) as cdef_file:
+        cdef_content += cdef_file.read()
+        # add newline for next file
+        cdef_content += '\n'
 ffi.cdef(cdef_content)
 
 if __name__ == "__main__":

--- a/libvmi/libvmi_cdef.h
+++ b/libvmi/libvmi_cdef.h
@@ -180,7 +180,57 @@ typedef struct registers {
 
 // page_info_t
 typedef struct page_info {
-    ...;
+    addr_t vaddr;
+    addr_t dtb;
+    addr_t paddr;
+    page_size_t size;
+
+    union {
+        struct {
+            addr_t pte_location;
+            addr_t pte_value;
+            addr_t pgd_location;
+            addr_t pgd_value;
+        } x86_legacy;
+
+        struct {
+            addr_t pte_location;
+            addr_t pte_value;
+            addr_t pgd_location;
+            addr_t pgd_value;
+            addr_t pdpe_location;
+            addr_t pdpe_value;
+        } x86_pae;
+
+        struct {
+            addr_t pte_location;
+            addr_t pte_value;
+            addr_t pgd_location;
+            addr_t pgd_value;
+            addr_t pdpte_location;
+            addr_t pdpte_value;
+            addr_t pml4e_location;
+            addr_t pml4e_value;
+        } x86_ia32e;
+
+        struct {
+            uint32_t fld_location;
+            uint32_t fld_value;
+            uint32_t sld_location;
+            uint32_t sld_value;
+        } arm_aarch32;
+
+        struct {
+            uint64_t zld_location;
+            uint64_t zld_value;
+            uint64_t fld_location;
+            uint64_t fld_value;
+            uint64_t sld_location;
+            uint64_t sld_value;
+            uint64_t tld_location;
+            uint64_t tld_value;
+        } arm_aarch64;
+    };
 } page_info_t;
 
 // access_context_t

--- a/libvmi/libvmi_extra_cdef.h
+++ b/libvmi/libvmi_extra_cdef.h
@@ -1,0 +1,3 @@
+GSList* vmi_get_va_pages(
+    vmi_instance_t vmi,
+    addr_t dtb);

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     setup_requires=["cffi>=1.6.0", "pkgconfig"],
     install_requires=["cffi>=1.6.0", "future"],
     tests_require=["pytest", "pytest-pep8"],
-    cffi_modules=['libvmi/glib_build.py:ffi', 'libvmi/libvmi_build.py:ffi'],
+    cffi_modules=['libvmi/libvmi_build.py:ffi'],
     packages=['libvmi'],
     package_data={
         'libvmi': ['*_cdef.h']


### PR DESCRIPTION
Implement `vmi_get_va_pages` from `libvmi_extra.h`

- removed `glib_build.py`, and integrated the glib functions into the main libvmi CFFI module
- add `get_va_pages` in `libvmi.py`
- add class `PageInfo` in `libvmi.py`