### PR TITLE
fix libvmi compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - cd /tmp/libvmi
   - ./autogen.sh
   - ./configure --prefix=/usr
-  - make -j4
+  - make
   - sudo make install
   - cd $OLDPWD
 


### PR DESCRIPTION
We have a race condition in `libvmi` compilation:
~~~
lexicon.l:30:21: fatal error: grammar.h: No such file or directory
 #include "grammar.h"
                     ^
compilation terminated.
updating grammar.h
~~~

Change from `make -j4` to `make` with one job at a time is the fix.