### PR TITLE
wrap get/set vcpuregs with Registers class

### DIFF
--- a/libvmi/__init__.py
+++ b/libvmi/__init__.py
@@ -2,6 +2,6 @@ from __future__ import absolute_import
 # public interface
 from .libvmi import INIT_DOMAINNAME, INIT_DOMAINID, INIT_EVENTS, INIT_SHM
 from .libvmi import (Libvmi, LibvmiError, VMIConfig, VMIMode, AccessContext,
-                     TranslateMechanism, X86Reg)
+                     TranslateMechanism, X86Reg, Registers)
 from .libvmi import VMIStatus, LibvmiInitError, PageMode
 from .libvmi import VMIArch, VMIOS, VMIWinVer


### PR DESCRIPTION
This PR wraps:
- `get_vcpuregs()`
- `set_vcpuregs()`

with a `Registers()` class, to avoid the user to directly interact with `registers_t *` cffi struct.

The issue is that the cffi `lib` import is only internal to `libvmi` and should not be exported.
Therefore the `get` method would still return a `registers_t`, but the `set` method would expect one from the user, even though he cannot create the structure.

This PR addresses this issue by wrapping the results with a `Registers` class.
Only `x86` regs are supported at the moment.

class docstring;
~~~Python
    """
    This class acts as a wrapper on top of
    vmi.get_vcpuregs and vmi.set_vcpuregs methods, only for x86.

    It is meant to be used as a dictionary:
    regs = vmi.get_vcpuregs(0)
    regs[X86Reg.RIP]

    regs = Registers()
    regs[X86Reg.RAX] = 0x42
    regs[X86Reg.RSP] = 0xabcd
    vmi.set_vcpuregs(regs, 0)

    for ARM architecture, there is no wrapper yet,
    use directly the cffi struct:
    regs = vmi.get_vcpuregs(0)
    regs.regs.arm.xxx
    """
~~~ 