### PR TITLE
detect libvmi/events.h at build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ install:
 
 script:
   - pep8 --show-source -v
+  - python -c 'from libvmi import Libvmi'

--- a/libvmi/libvmi_build.py
+++ b/libvmi/libvmi_build.py
@@ -2,7 +2,6 @@
 
 
 import os
-from pathlib import Path
 
 import pkgconfig
 from cffi import FFI
@@ -23,6 +22,7 @@ VMI_SOURCES = [
     '<libvmi/libvmi_extra.h>'
 ]
 
+
 def get_cflags(package):
     includes = pkgconfig.cflags(package)
     if not includes:
@@ -40,13 +40,14 @@ def get_libs(package):
     libs = libs.replace('-l', '').split(' ')
     return libs
 
+
 def check_header(header):
     inc_path_list = [
         '/usr/include',
         '/usr/local/include'
     ]
     for inc_path in inc_path_list:
-        if (Path(inc_path) / header).exists():
+        if os.path.exists(inc_path + '/' + header):
             return True
     return False
 


### PR DESCRIPTION
Should help solving https://github.com/libvmi/python/issues/13#issuecomment-449019489
We detect the `libvmi/events.h` header when the bindings are built.