### PR TITLE
Debug events

### DIFF
--- a/examples/debug-event.py
+++ b/examples/debug-event.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+"""Debug Event example.
+
+Usage:
+  debug-event.py [options] <vm_name> <symbol>
+
+Options:
+  -h --help     Show this screen.
+"""
+
+# This example works until the guest decides to reset DR7
+# We need to catch MOV-TO-DRx event to improve it
+
+import sys
+import signal
+from pprint import pprint
+
+from docopt import docopt
+from libvmi import Libvmi, INIT_DOMAINNAME, INIT_EVENTS, X86Reg
+from libvmi.event import DebugEvent, SingleStepEvent, EventResponse
+from utils import dtb_to_pname, pause
+
+
+# catch SIGINT
+# we cannot rely on KeyboardInterrupt when we are in
+# the vmi.listen() call
+interrupted = False
+
+
+def set_bit(value, index, enabled):
+    mask = 1 << index
+    if enabled:
+        value |= mask
+    else:
+        value &= ~mask
+    return value
+
+
+def toggle_dr0(vmi, enabled):
+    # enable dr0 globally
+    value = set_bit(0, 1, enabled)
+    vmi.set_vcpureg(value, X86Reg.DR7.value, 0)
+
+
+def signal_handler(signal, frame):
+    global interrupted
+    interrupted = True
+
+
+def sstep_callback(vmi, event):
+    toggle_dr0(vmi, True)
+    # disable singlestep
+    return EventResponse.TOGGLE_SINGLESTEP
+
+
+def debug_callback(vmi, event):
+    pprint(event.to_dict())
+    event.reinject = 0
+    toggle_dr0(vmi, False)
+    # enable singlestep
+    return EventResponse.TOGGLE_SINGLESTEP
+
+
+def main(args):
+    vm_name = args['<vm_name>']
+    symbol = args['<symbol>']
+
+    # register SIGINT
+    signal.signal(signal.SIGINT, signal_handler)
+
+    with Libvmi(vm_name, INIT_DOMAINNAME | INIT_EVENTS) as vmi:
+        vaddr = vmi.translate_ksym2v(symbol)
+
+        debug_event = DebugEvent(debug_callback)
+
+        num_vcpus = vmi.get_num_vcpus()
+        sstep_event = SingleStepEvent(range(num_vcpus), enable=False,
+                                      callback=sstep_callback)
+        with pause(vmi):
+            vmi.register_event(debug_event)
+            vmi.register_event(sstep_event)
+            # set dr0 to our address
+            vmi.set_vcpureg(vaddr, X86Reg.DR0.value, 0)
+            toggle_dr0(vmi, True)
+
+        # listen
+        while not interrupted:
+            print("Waiting for events")
+            vmi.listen(1000)
+        print("Stop listening")
+
+        with pause(vmi):
+            vmi.clear_event(debug_event)
+            vmi.clear_event(sstep_event)
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    ret = main(args)
+    sys.exit(ret)

--- a/libvmi/event.py
+++ b/libvmi/event.py
@@ -250,3 +250,38 @@ class IntEvent(Event):
         d['intr'] = self.intr.name
         d['reinject'] = self._reinject
         return d
+
+
+class DebugEvent(Event):
+
+    type = EventType.DEBUG_EXCEPTION
+
+    def __init__(self, callback, reinject=-1,
+                 slat_id=0, data=None):
+        super().__init__(callback, slat_id, data)
+        self._reinject = reinject
+
+    @property
+    def reinject(self):
+        return self._reinject
+
+    @reinject.setter
+    def reinject(self, value):
+        # the event callback needs to set the reinjection
+        # behavior
+        self._reinject = value
+        self._cffi_event.debug_event.reinject = self._reinject
+
+    def to_cffi(self):
+        super().to_cffi()
+        self._cffi_event.debug_event.reinject = self._reinject
+        return self._cffi_event
+
+    def to_dict(self):
+        d = super().to_dict()
+        d['gla'] = hex(self._cffi_event.debug_event.gla)
+        d['gfn'] = hex(self._cffi_event.debug_event.gfn)
+        d['offset'] = hex(self._cffi_event.debug_event.offset)
+        d['type'] = hex(self._cffi_event.debug_event.type)
+        d['reinject'] = self._reinject
+        return d

--- a/libvmi/events_cdef.h
+++ b/libvmi/events_cdef.h
@@ -103,6 +103,12 @@ typedef struct {
 
 // debug_event_t
 typedef struct {
+    addr_t gla;
+    addr_t gfn;
+    addr_t offset;
+    uint32_t insn_length;
+    uint8_t type;
+    int8_t reinject;
     ...;
 } debug_event_t;
 

--- a/libvmi/libvmi.py
+++ b/libvmi/libvmi.py
@@ -37,6 +37,14 @@ class X86Reg(Enum):
     CR0 = lib.CR0
     CR2 = lib.CR2
     CR3 = lib.CR3
+    CR4 = lib.CR4
+
+    DR0 = lib.DR0
+    DR1 = lib.DR1
+    DR2 = lib.DR2
+    DR3 = lib.DR3
+    DR6 = lib.DR6
+    DR7 = lib.DR7
 
 
 class Registers:

--- a/libvmi/libvmi_cdef.h
+++ b/libvmi/libvmi_cdef.h
@@ -41,6 +41,15 @@
 #define CR0             18
 #define CR2             19
 #define CR3             20
+#define CR4             21
+#define XCR0            22
+
+#define DR0             23
+#define DR1             24
+#define DR2             25
+#define DR3             26
+#define DR6             27
+#define DR7             28
 
 // vmi_instance_t
 typedef struct vmi_instance *vmi_instance_t;


### PR DESCRIPTION
This PR adds support for debug events through `DebugEvent` class.

It adds en example which sets a breakpoint in DR0 and enables the breakpoint in DR7, and catching the following events.