### PR TITLE
Expose init_data as a Python type

### DIFF
--- a/examples/demo_cr3.py
+++ b/examples/demo_cr3.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""CR3 example.
+
+Usage:
+  cr3-event.py [options] <vm_name>
+
+Options:
+  -h --help     Show this screen.
+  -k SOCKET --kvmi-socket SOCKET        If hypervisor is KVM, specify the KVMi socket
+"""
+
+import sys
+import signal
+import logging
+from collections import Counter
+
+from docopt import docopt
+
+from libvmi import Libvmi, X86Reg, INIT_DOMAINNAME, INIT_EVENTS, VMIInitData
+from libvmi.event import RegEvent, RegAccess
+
+from utils import pause
+
+
+# catch SIGINT
+# we cannot rely on KeyboardInterrupt when we are in
+# the vmi.listen() call
+interrupted = False
+
+
+def signal_handler(signal, frame):
+    global interrupted
+    interrupted = True
+
+
+def main(args):
+    logging.basicConfig(level=logging.INFO)
+    vm_name = args['<vm_name>']
+
+    # register SIGINT
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # 1 - init LibVMI
+    kvm_socket = {VMIInitData.KVMI_SOCKET: args['--kvmi-socket']} if args['--kvmi-socket'] else None
+    with Libvmi(vm_name, INIT_DOMAINNAME | INIT_EVENTS, init_data=kvm_socket, partial=True) as vmi:
+        counter = Counter()
+
+        # 2 - define CR3 callback
+        def cr3_callback(vmi, event):
+            cr3_value = event.value
+            logging.info("CR3 change: %s", hex(cr3_value))
+            counter[hex(cr3_value)] += 1
+
+        # 3 - define and register CR3-write event
+        with pause(vmi):
+            # register CR3-write event
+            reg_event = RegEvent(X86Reg.CR3, RegAccess.W, cr3_callback)
+            vmi.register_event(reg_event)
+
+        # 4 - listen for events
+        for i in range(0, 100):
+            vmi.listen(500)
+        logging.info(counter)
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    ret = main(args)
+    sys.exit(ret)

--- a/examples/demo_mem_event.py
+++ b/examples/demo_mem_event.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""Memory Access example.
+
+Usage:
+  memaccess-event.py [options] <vm_name>
+
+Options:
+  -h --help     Show this screen.
+  -k SOCKET --kvmi-socket SOCKET        If hypervisor is KVM, specify the KVMi socket
+"""
+
+import sys
+import signal
+import logging
+
+from docopt import docopt
+from libvmi import Libvmi, INIT_DOMAINNAME, INIT_EVENTS, VMIInitData, X86Reg
+from libvmi.event import MemEvent, MemAccess
+from utils import pause
+
+# catch SIGINT
+# we cannot rely on KeyboardInterrupt when we are in
+# the vmi.listen() call
+interrupted = False
+
+
+def signal_handler(signal, frame):
+    global interrupted
+    interrupted = True
+
+
+def main(args):
+    logging.basicConfig(level=logging.INFO)
+    vm_name = args['<vm_name>']
+
+    # register SIGINT
+    signal.signal(signal.SIGINT, signal_handler)
+
+    kvm_socket = {VMIInitData.KVMI_SOCKET: args['--kvmi-socket']} if args['--kvmi-socket'] else None
+    with Libvmi(vm_name, INIT_DOMAINNAME | INIT_EVENTS, init_data=kvm_socket, partial=True) as vmi:
+        # init paging to translate virtual addresses
+        vmi.init_paging(0)
+        with pause(vmi):
+            # get current RIP on VCPU 0
+            rip = vmi.get_vcpureg(X86Reg.RIP.value, 0)
+            # get DTB
+            cr3 = vmi.get_vcpureg(X86Reg.CR3.value, 0)
+            dtb = cr3 & ~0xfff
+            # get gpa
+            paddr = vmi.pagetable_lookup(dtb, rip)
+            gfn = paddr >> 12
+
+            # define callback
+            def cb_mem_event(vmi, event):
+                logging.info("Mem event at RIP: %s, frame: %s, offset: %s, permissions: %s",
+                             hex(event.x86_regs.rip), hex(event.gla), hex(event.offset), event.out_access.name)
+
+            mem_event = MemEvent(MemAccess.X, cb_mem_event, gfn=gfn)
+            vmi.register_event(mem_event)
+        # listen
+        while not interrupted:
+            vmi.listen(3000)
+        logging.info("stop listening")
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    ret = main(args)
+    sys.exit(ret)

--- a/examples/memaccess-event.py
+++ b/examples/memaccess-event.py
@@ -52,7 +52,7 @@ def cb_mem_event(vmi, event):
 
 def cb_ss_event(vmi, event):
     # out of the frame ?
-    if event.cffi_event.ss_event.gfn != event.data['target_gfn']:
+    if event.cffi_event.ss_event._gfn != event.data['target_gfn']:
         print("reregister event")
         # reregister mem event
         vmi.register_event(event.data['mem_event'])

--- a/libvmi/__init__.py
+++ b/libvmi/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 # public interface
 from .libvmi import INIT_DOMAINNAME, INIT_DOMAINID, INIT_EVENTS
-from .libvmi import (Libvmi, LibvmiError, VMIConfig, VMIMode, AccessContext,
+from .libvmi import (Libvmi, LibvmiError, VMIConfig, VMIMode, VMIInitData, AccessContext,
                      TranslateMechanism, X86Reg, Registers)
 from .libvmi import VMIStatus, LibvmiInitError, PageMode
 from .libvmi import VMIArch, VMIOS, VMIWinVer

--- a/libvmi/__init__.py
+++ b/libvmi/__init__.py
@@ -1,8 +1,9 @@
 # flake8: noqa
 from __future__ import absolute_import
+
 # public interface
-from .libvmi import INIT_DOMAINNAME, INIT_DOMAINID, INIT_EVENTS
-from .libvmi import (Libvmi, LibvmiError, VMIConfig, VMIMode, VMIInitData, AccessContext,
-                     TranslateMechanism, X86Reg, Registers)
-from .libvmi import VMIStatus, LibvmiInitError, PageMode
-from .libvmi import VMIArch, VMIOS, VMIWinVer
+from .libvmi import (INIT_DOMAINID, INIT_DOMAINNAME, INIT_EVENTS, VMIOS,
+                     AccessContext, Libvmi, LibvmiError, LibvmiInitError,
+                     PageMode, Registers, TranslateMechanism, VMIArch,
+                     VMIConfig, VMIInitData, VMIMode, VMIStatus, VMIWinVer,
+                     X86Reg)

--- a/libvmi/event.py
+++ b/libvmi/event.py
@@ -201,6 +201,14 @@ class RegEvent(Event):
         if self.equal is None:
             self.equal = 0
 
+    @property
+    def value(self):
+        return self._cffi_event.reg_event.value
+
+    @value.setter
+    def value(self, v):
+        self._cffi_event.reg_event.value = v
+
     def to_cffi(self):
         super().to_cffi()
         self._cffi_event.reg_event.reg = self.register.value

--- a/libvmi/event.py
+++ b/libvmi/event.py
@@ -4,7 +4,6 @@ from enum import Enum
 
 from _libvmi import ffi, lib
 
-
 EVENTS_VERSION = lib.VMI_EVENTS_VERSION
 
 

--- a/libvmi/event.py
+++ b/libvmi/event.py
@@ -161,7 +161,7 @@ class MemEvent(Event):
 
     @property
     def out_access(self):
-        return self._cffi_event.mem_event.out_access
+        return MemAccess(self._cffi_event.mem_event.out_access)
 
     @property
     def gptw(self):

--- a/libvmi/event.py
+++ b/libvmi/event.py
@@ -144,9 +144,36 @@ class MemEvent(Event):
     def __init__(self, in_access, callback, gfn=0, generic=False, slat_id=0,
                  data=None):
         super().__init__(callback, slat_id, data)
+        # IN
         self.in_access = in_access
+        # IN
         self.generic = generic
-        self.gfn = gfn
+        # IN/OUT
+        self._gfn = gfn
+
+    @property
+    def gfn(self):
+        return self._cffi_event.mem_event.gfn
+
+    @property
+    def out_access(self):
+        return self._cffi_event.mem_event.out_access
+
+    @property
+    def gptw(self):
+        return bool(self._cffi_event.mem_event.gptw)
+
+    @property
+    def gla_valid(self):
+        return bool(self._cffi_event.mem_event.gla_valid)
+
+    @property
+    def gla(self):
+        return self._cffi_event.mem_event.gla
+
+    @property
+    def offset(self):
+        return self._cffi_event.mem_event.offset
 
     def to_cffi(self):
         super().to_cffi()
@@ -155,15 +182,16 @@ class MemEvent(Event):
         if self.generic:
             self._cffi_event.mem_event.gfn = ctypes.c_ulonglong(~0).value
         else:
-            self._cffi_event.mem_event.gfn = self.gfn
+            self._cffi_event.mem_event.gfn = self._gfn
         return self._cffi_event
 
     def to_dict(self):
         d = super().to_dict()
+        d['gfn'] = self.gfn
         d['in_access'] = self.in_access.name
-        d['out_access'] = MemAccess(self._cffi_event.mem_event.out_access).name
-        d['gptw'] = bool(self._cffi_event.mem_event.gptw)
-        d['gla_valid'] = bool(self._cffi_event.mem_event.gla_valid)
+        d['out_access'] = self.out_access.name
+        d['gptw'] = self.gptw
+        d['gla_valid'] = self.gla_valid
         d['gla'] = hex(self._cffi_event.mem_event.gla)
         d['offset'] = hex(self._cffi_event.mem_event.offset)
         return d
@@ -287,7 +315,7 @@ class DebugEvent(Event):
     def to_dict(self):
         d = super().to_dict()
         d['gla'] = hex(self._cffi_event.debug_event.gla)
-        d['gfn'] = hex(self._cffi_event.debug_event.gfn)
+        d['gfn'] = hex(self._cffi_event.debug_event._gfn)
         d['offset'] = hex(self._cffi_event.debug_event.offset)
         d['type'] = hex(self._cffi_event.debug_event.type)
         d['reinject'] = self._reinject

--- a/libvmi/event.py
+++ b/libvmi/event.py
@@ -92,6 +92,10 @@ class Event(object):
         self._cffi_event = ffi.new("vmi_event_t *")
 
     @property
+    def x86_regs(self):
+        return self._cffi_event.x86_regs
+
+    @property
     def vmi(self):
         return self._vmi
 

--- a/libvmi/libvmi.py
+++ b/libvmi/libvmi.py
@@ -168,6 +168,12 @@ class TranslateMechanism(Enum):
     KERNEL_SYMBOL = lib.VMI_TM_KERNEL_SYMBOL
 
 
+class VMIInitData(Enum):
+    XEN_EVTCHN = lib.VMI_INIT_DATA_XEN_EVTCHN
+    MEMMAP = lib.VMI_INIT_DATA_MEMMAP
+    KVMI_SOCKET = lib.VMI_INIT_DATA_KVMI_SOCKET
+
+
 class AccessContext(object):
 
     def __init__(self, tr_mechanism=TranslateMechanism.NONE, addr=0,
@@ -217,7 +223,7 @@ class Libvmi(object):
         'vmi',
     )
 
-    def __init__(self, domain, init_flags=INIT_DOMAINNAME, init_data=ffi.NULL,
+    def __init__(self, domain, init_flags=INIT_DOMAINNAME, init_data=None,
                  config_mode=VMIConfig.GLOBAL_FILE_ENTRY, config=ffi.NULL,
                  mode=None, partial=False):
         self.vmi = ffi.NULL
@@ -226,11 +232,27 @@ class Libvmi(object):
         # avoid GC to free ghashtable inserted values
         ghash_ref = dict()
         ghash = None
+        # keep references on ffi buffers, avoid issues with GC
+        ffi_refs = {
+            'init_data': []
+        }
+        init_data_ffi = ffi.NULL
+        if init_data:
+            init_data_ffi = ffi.new("vmi_init_data_t *", {"entry": len(init_data)})
+            init_data_ffi.count = len(init_data)
+            for i, (e_type, e_value) in enumerate(init_data.items()):
+                init_data_ffi.entry[i].type = e_type.value
+                if not isinstance(e_value, str):
+                    raise RuntimeError("Passing anything else than a string as init_data value is not implemented")
+                ref = e_value.encode()
+                init_data_ffi.entry[i].data = ffi.from_buffer(ref)
+                # keep a ref !
+                ffi_refs['init_data'].append(ref)
         if partial:
             # vmi_init
             if not mode:
                 # calling vmi_get_access_mode to auto determine vmi_mode
-                mode = self.get_access_mode(domain, init_flags, init_data)
+                mode = self.get_access_mode(domain, init_flags, init_data_ffi)
             if not isinstance(mode, VMIMode):
                 raise RuntimeError("mode is not an instance of VMIMode")
             if (not init_flags & INIT_DOMAINNAME and
@@ -243,7 +265,7 @@ class Libvmi(object):
                                   mode.value,
                                   domain,
                                   init_flags,
-                                  init_data,
+                                  init_data_ffi,
                                   init_error)
         else:
             # vmi_init_complete
@@ -280,7 +302,7 @@ class Libvmi(object):
             status = lib.vmi_init_complete(self.opaque_vmi,
                                            domain,
                                            init_flags,
-                                           init_data,
+                                           init_data_ffi,
                                            config_mode.value,
                                            config,
                                            init_error)

--- a/libvmi/libvmi.py
+++ b/libvmi/libvmi.py
@@ -1,8 +1,8 @@
-from future.utils import raise_from
 from builtins import bytes, object, str
 from enum import Enum
 
 from _libvmi import ffi, lib
+from future.utils import raise_from
 
 # export libvmi defines
 INIT_DOMAINNAME = lib.VMI_INIT_DOMAINNAME

--- a/libvmi/libvmi_build.py
+++ b/libvmi/libvmi_build.py
@@ -6,7 +6,6 @@ import os
 import pkgconfig
 from cffi import FFI
 
-
 # glib_cdef.h must be first
 CDEF_HEADERS = [
     'glib_cdef.h',

--- a/libvmi/libvmi_cdef.h
+++ b/libvmi/libvmi_cdef.h
@@ -202,6 +202,24 @@ typedef enum page_size {
 
 } page_size_t;
 
+typedef enum {
+    VMI_INIT_DATA_XEN_EVTCHN, /**< Xen file descriptor */
+
+    VMI_INIT_DATA_MEMMAP,    /**< memory_map_t pointer */
+
+    VMI_INIT_DATA_KVMI_SOCKET     /**< kvmi socket path */
+} vmi_init_data_type_t;
+
+typedef struct {
+    uint64_t type; /**< type (VMI_INIT_DATA_*) */
+    void *data;    /**< the data being passed in */
+} vmi_init_data_entry_t;
+
+typedef struct {
+    uint64_t count;  /**< number of entries */
+    vmi_init_data_entry_t entry[]; /**< entry for each data being passed in */
+} vmi_init_data_t;
+
 typedef uint64_t reg_t;
 
 /*


### PR DESCRIPTION
This PR allows to pass an `init_data` to Libvmi's constructor.

Only a string can be passed for now, so `VMI_INIT_DATA_KVMI_SOCKET` can be used.
![Screenshot_20190917_213512](https://user-images.githubusercontent.com/964610/65073783-d2b4e080-d993-11e9-9b60-121442cfca6c.png)
