### PR TITLE
fix typo in get_vcpureg API

### DIFF
--- a/libvmi/libvmi.py
+++ b/libvmi/libvmi.py
@@ -834,7 +834,7 @@ class Libvmi(object):
         check(status)
 
     # TODO needs a reg_t
-    def get_vcpu_reg(self, reg, vcpu):
+    def get_vcpureg(self, reg, vcpu):
         value = ffi.new("uint64_t *")
         status = lib.vmi_get_vcpureg(self.vmi, value, reg, vcpu)
         check(status)


### PR DESCRIPTION
There was a typo in `get_vcpureg` API, as it was named `get_vcpu_reg`.
https://github.com/libvmi/libvmi/blob/master/libvmi/libvmi.h#L2217

This is fixed by this PR.