### PR TITLE
events: update VMI_EVENTS_VERSION to 0x7

### DIFF
--- a/libvmi/events_cdef.h
+++ b/libvmi/events_cdef.h
@@ -1,4 +1,4 @@
-#define VMI_EVENTS_VERSION 0x00000006
+#define VMI_EVENTS_VERSION 0x00000007
 
 typedef uint16_t vmi_event_type_t;
 


### PR DESCRIPTION
Update `VMI_EVENTS_VERSION` after https://github.com/libvmi/libvmi/pull/893

fixes issue https://github.com/Wenzel/pyvmidbg/issues/46