### PR TITLE
ci: add publish job to publish package on PyPI

### DIFF
--- a/.github/actions/libvmi-setup/action.yml
+++ b/.github/actions/libvmi-setup/action.yml
@@ -1,0 +1,25 @@
+name: 'Libvmi setup'
+description: 'This actions installs LibVMI on the system'
+author: 'Mathieu Tarral'
+runs:
+    using: 'composite'
+    steps:
+      - name: install dependencies
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -qq cmake bison flex check libjson-c-dev libglib2.0-dev libxenstore3.0 libxen-dev libvirt-dev
+
+      - name: clone libvmi
+        uses: actions/checkout@v2
+        with:
+          repository: libvmi/libvmi
+          path: libvmi
+          # pinned to a specific commit to avoid breakage
+          ref: 'f9db2f45670b08c0f142a1d2d31e0b15e724815c'
+
+      - name: install libvmi
+        shell: bash
+        run: |
+          cmake -B build -DCMAKE_INSTALL_PREFIX=/usr .
+          cmake --build build
+          sudo cmake --build build --target install
+        working-directory: libvmi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,28 @@ jobs:
           python setup.py bdist_wheel
         working-directory: python-libvmi
 
-      - name: publish on PyPI 🚀
-        # push on master and tag is 'v*'
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+
+    # if push on master and tag is 'v*'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python 3.7 🐍
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+
+      - name: Build 🔨
+        run: |
+          python -m pip install wheel
+          python setup.py sdist
+          python setup.py bdist_wheel
+
+      - name: Publish on PyPI 🚀
         uses: pypa/gh-action-pypi-publish@v1.3.1
         with:
           user: __token__
           password: ${{ secrets.ACCESS_TOKEN }}
-          packages_dir: python-libvmi/dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,28 +37,13 @@ jobs:
         with:
           path: python-libvmi
 
+      - name: Install Libvmi
+        uses: ./python-libvmi/.github/actions/libvmi-setup
+
       - name: Set up Python 🐍
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-
-      - name: install dependencies
-        run: sudo apt-get update && sudo apt-get install -qq cmake bison flex check libjson-c-dev libglib2.0-dev libxenstore3.0 libxen-dev libvirt-dev
-
-      - name: clone libvmi
-        uses: actions/checkout@v2
-        with:
-          repository: libvmi/libvmi
-          path: libvmi
-          # pinned to a specific commit to avoid breakage
-          ref: 'f9db2f45670b08c0f142a1d2d31e0b15e724815c'
-
-      - name: install libvmi
-        run: |
-          cmake -B build -DCMAKE_INSTALL_PREFIX=/usr .
-          cmake --build build
-          sudo cmake --build build --target install
-        working-directory: libvmi
 
       - name: install python-libvmi 🔨
         run: |
@@ -83,6 +68,9 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v1
+
+      - name: Install Libvmi
+        uses: ./.github/actions/libvmi-setup
 
       - name: Set up Python 3.7 🐍
         uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           repository: libvmi/libvmi
           path: libvmi
+          # pinned to a specific commit to avoid breakage
+          ref: 'f9db2f45670b08c0f142a1d2d31e0b15e724815c'
 
       - name: install libvmi
         run: |


### PR DESCRIPTION
- Refactor `ci.yml` and extract the package publication from the `build` job into a separate `publish` job that will only be triggered by a push on master branch with a tag format.
- pin libvmi to https://github.com/libvmi/libvmi/commit/f9db2f45670b08c0f142a1d2d31e0b15e724815c in the CI.
- add common action to setup libvmi