### PR TITLE
wrong type for cs_arbytes

### DIFF
--- a/libvmi/libvmi_cdef.h
+++ b/libvmi/libvmi_cdef.h
@@ -302,7 +302,7 @@ typedef struct x86_regs {
     uint64_t msr_lstar;
     uint64_t fs_base;
     uint64_t gs_base;
-    uint32_t cs_arbytes;
+    uint64_t cs_arbytes;
     ...;
 } x86_registers_t;
 


### PR DESCRIPTION
Wrong type in cs_arbyes do not permit to use event.x86_regs.xxx for MemEvent callbacks 

eg:
```
def callback(vmi, event):
  print(hex(event.x86_regs.rip))